### PR TITLE
Fix calling getFieldsetCss() on null

### DIFF
--- a/Block/Adminhtml/System/Config/CustomFieldset.php
+++ b/Block/Adminhtml/System/Config/CustomFieldset.php
@@ -2,12 +2,18 @@
 
 namespace Pointspay\Pointspay\Block\Adminhtml\System\Config;
 
+use Magento\Backend\Block\Context;
+use Magento\Backend\Model\Auth\Session;
 use Magento\Config\Block\System\Config\Form\Field;
 use Magento\Config\Block\System\Config\Form\Fieldset;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Data\Form\Element\AbstractElement;
 use Magento\Framework\DataObject;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\View\Helper\Js;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Pointspay\Pointspay\Block\System\Config\DownloadCertificate;
 use Psr\Log\LoggerInterface;
 
@@ -88,10 +94,14 @@ class CustomFieldset extends Fieldset
 
     /**
      * CustomFieldset constructor.
-     * @param \Magento\Backend\Block\Template\Context $context
+     *
+     * @param Context $context
+     * @param Session $authSession
+     * @param Js $jsHelper
+     * @param ScopeConfigInterface $scopeConfig
+     * @param SerializerInterface $serializer
+     * @param StoreManagerInterface $storeManager
      * @param LoggerInterface $logger
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
-     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
      * @param array $data
      */
     public function __construct(
@@ -101,12 +111,14 @@ class CustomFieldset extends Fieldset
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Framework\Serialize\SerializerInterface   $serializer,
         \Magento\Store\Model\StoreManagerInterface         $storeManager,
+        LoggerInterface                                    $logger,
         array                                              $data = []
     )
     {
         $this->scopeConfig = $scopeConfig;
         $this->serializer = $serializer;
         $this->storeManager = $storeManager;
+        $this->logger = $logger;
         parent::__construct($context, $authSession, $jsHelper, $data);
     }
 

--- a/Block/Adminhtml/System/Config/Fieldset.php
+++ b/Block/Adminhtml/System/Config/Fieldset.php
@@ -42,6 +42,20 @@ class Fieldset extends \Magento\Config\Block\System\Config\Form\Fieldset
         return $html;
     }
 
+    protected function _getFieldsetCss()
+    {
+        /** @var \Magento\Config\Model\Config\Structure\Element\Group $group */
+        $group = $this->getGroup();
+
+        if (!$group) {
+            return 'config admin__collapsible-block';
+        }
+
+        $configCss = $group->getFieldsetCss();
+        return 'config admin__collapsible-block' . ($configCss ? ' ' . $configCss : '');
+    }
+
+
     /**
      * Get collapsed state on-load
      *

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "pointspay/pointspay-magento",
-    "version": "3.3.6",
+    "version": "3.3.7",
     "description": "Pointspay payment",
     "type": "magento2-module",
     "require": {


### PR DESCRIPTION
- Fix `Call to a member function getFieldsetCss() on null` issue overriding the Magento's `Fieldset` and adding a null exception safeguard.
- Define uninitialized parameters in the `CustomFieldSet` class and update the constructor.
- Update plugin version to 3.3.7